### PR TITLE
feat: Internal HTTP client

### DIFF
--- a/src/internal/http/client.go
+++ b/src/internal/http/client.go
@@ -1,0 +1,55 @@
+package httpclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type Client struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+func New(baseURL string) *Client {
+	return &Client{
+		BaseURL:    baseURL,
+		HTTPClient: http.DefaultClient,
+	}
+}
+
+func (c *Client) DoRequest(ctx context.Context, method, path string, body any, result any) error {
+	var bodyReader io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal body: %w", err)
+		}
+		bodyReader = bytes.NewBuffer(buf)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("received non-2xx status: %d", resp.StatusCode)
+	}
+
+	if result != nil {
+		return json.NewDecoder(resp.Body).Decode(result)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request introduces a new HTTP client implementation in the `src/internal/http/client.go` file. The changes include creating a reusable `Client` struct and a method for making HTTP requests with JSON payloads. 

Key additions:

* **New HTTP client implementation**:
  - Added a `Client` struct with `BaseURL` and `HTTPClient` fields to encapsulate HTTP request logic. (`[src/internal/http/client.goR1-R55](diffhunk://#diff-4c8f1c82d531325f746bcffc32d560142e21f4fd0e1946234b972343c6eda7beR1-R55)`)
  - Implemented a `New` function to initialize the `Client` with a base URL and the default HTTP client. (`[src/internal/http/client.goR1-R55](diffhunk://#diff-4c8f1c82d531325f746bcffc32d560142e21f4fd0e1946234b972343c6eda7beR1-R55)`)
  - Added a `DoRequest` method to handle HTTP requests, including JSON serialization for the request body and deserialization for the response body. It also includes error handling for non-2xx status codes. (`[src/internal/http/client.goR1-R55](diffhunk://#diff-4c8f1c82d531325f746bcffc32d560142e21f4fd0e1946234b972343c6eda7beR1-R55)`)